### PR TITLE
Port Smpp.NET to .NET Standard 2.0

### DIFF
--- a/EsmeGui/EsmeGui.csproj
+++ b/EsmeGui/EsmeGui.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EsmeGui</RootNamespace>
     <AssemblyName>EsmeGui</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Smpp.NET/Properties/AssemblyInfo.cs
+++ b/Smpp.NET/Properties/AssemblyInfo.cs
@@ -1,20 +1,6 @@
 ﻿using System;
 using System.Security;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Smpp.NET")]
-[assembly: AssemblyDescription("SMS Peer to Peer Library")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("JulMar Technology, Inc.")]
-[assembly: AssemblyProduct("Smpp.NET")]
-[assembly: AssemblyCopyright("Copyright ©  2008 JulMar Technolgy, Inc.")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -26,15 +12,3 @@ using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(true)]
 [assembly: AllowPartiallyTrustedCallers]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers 
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/Smpp.NET/Smpp.NET.csproj
+++ b/Smpp.NET/Smpp.NET.csproj
@@ -1,30 +1,28 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RootNamespace>JulMar.Smpp</RootNamespace>
+    <AssemblyName>Smpp.NET</AssemblyName>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <Version>9.0.21022</Version>
+    <Description>SMS Peer to Peer Library</Description>
+    <Company>JulMar Technology, Inc.</Company>
+    <Product>Smpp.NET</Product>
+    <Copyright>Copyright © 2008 JulMar Technolgy, Inc.</Copyright>
+    <RepositoryUrl>https://github.com/markjulmar/smpp.net.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{70EC99F8-FB12-4CB2-A453-A0057A04BF05}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>JulMar.Smpp</RootNamespace>
-    <AssemblyName>Smpp.NET</AssemblyName>
-    <SccProjectName>
-    </SccProjectName>
-    <SccLocalPath>
-    </SccLocalPath>
-    <SccAuxPath>
-    </SccAuxPath>
-    <SccProvider>
-    </SccProvider>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -61,11 +59,10 @@
     <DocumentationFile>bin\Release\Smpp.NET.XML</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+
+  <PropertyGroup>
+    <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />
     <Compile Include="Elements\additional_status_info_text.cs" />
@@ -244,34 +241,5 @@
     <Compile Include="Utility\Sockets.cs" />
     <Compile Include="Utility\TLV.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 2.0 %28x86%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.0 %28x86%29</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/TestEsme/TestEsme.csproj
+++ b/TestEsme/TestEsme.csproj
@@ -14,7 +14,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>


### PR DESCRIPTION
- Bump the EsmeGui and TestEsme Framework versions from 4.6 to 4.6.1,
  since .NET Standard 2.0 is only supported by 4.6.1 and above.
- Set EnableDefaultCompileItems to false in csproj, because the new SDK
  convention is to add all .cs files by default, and some of them cannot
  be compiled due to missing dependencies.
- Move some attributes from AssemblyInfo.cs to the csproj, to avoid
  conflicts with auto-generated attributes.
- Clean up csproj.

Closes: #1